### PR TITLE
Hackspace Specific API Calls

### DIFF
--- a/Hackspaces/Models/SpaceApiTypes.swift
+++ b/Hackspaces/Models/SpaceApiTypes.swift
@@ -7,24 +7,21 @@
 
 import Foundation
 
-struct Feeds: Codable {
-    var type: String
-    var url: URL
+struct Location: Codable {
+    var address: String
+    var lat: Double
+    var lon: Double
 }
 
-struct Contact: Codable {
-    var twitter: String
-    var email: String
-}
-
-struct Data: Codable {
-    var api: String
-    var contact: Contact
-    var feeds: Feeds
-    var issuereportchannels: String
-}
 
 struct SpaceApi: Codable {
     var space: String
-    var logo: String
+    var logo: URL?
+    var url: URL
+    var location: Location
+    var state: spaceState
+
+    struct spaceState: Codable {
+        var open: Bool
+    }
 }

--- a/Hackspaces/Models/SpaceApiTypes.swift
+++ b/Hackspaces/Models/SpaceApiTypes.swift
@@ -25,17 +25,6 @@ struct Data: Codable {
 }
 
 struct SpaceApi: Codable {
-    var url: URL
-    var valid: Bool
-    var lastSeen: Date
-    var data: Data
-}
-
-struct DirectoryApi: Decodable {
-    let mappings: [String: String]
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        mappings = try container.decode([String: String].self)
-    }
+    var space: String
+    var logo: String
 }

--- a/Hackspaces/Views/ContentView.swift
+++ b/Hackspaces/Views/ContentView.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-func makeAPICall(completion: @escaping ([String]?) -> Void) {
+func makeDirectoryAPICall(completion: @escaping ([(name: String, apiUrl: String)]?) -> Void) {
     // Specify the URL for the API endpoint
     let apiUrl = URL(string: "https://directory.spaceapi.io")!
 
@@ -31,12 +31,9 @@ func makeAPICall(completion: @escaping ([String]?) -> Void) {
         }
 
         do {
-            // Parse the data using JSONDecoder (replace YourModel.self with your actual data model)
-            let result = try JSONDecoder().decode(DirectoryApi.self, from: data)
-            // Use the 'result' variable to access the data from the API call
-            var keys = Array(result.mappings.keys)
-            keys.sort()
-            completion(keys)
+            let result = try JSONDecoder().decode([String: String].self, from: data)
+            let hackspaceUrls = result.map { (name: $0.key, apiUrl: $0.value) }.sorted { $0.name < $1.name }
+            completion(hackspaceUrls)
             print("API has been called")
         } catch let jsonError {
             print("Error decoding JSON: \(jsonError)")
@@ -44,6 +41,44 @@ func makeAPICall(completion: @escaping ([String]?) -> Void) {
     }
 
     // Start the URLSession task
+    task.resume()
+}
+
+func makeSpaceAPICall(for apiUrl: String, completion: @escaping (SpaceApi?) -> Void) {
+    guard let url = URL(string: apiUrl) else {
+        print("Invalid URL")
+        completion(nil)
+        return
+    }
+
+    let task = URLSession.shared.dataTask(with: url) { data, response, error in
+            if let error = error {
+                print("Error: \(error.localizedDescription)")
+                completion(nil)
+                return
+            }
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            print("Invalid response or status code")
+            completion(nil)
+            return
+        }
+
+        guard let data = data else {
+            print("No data received")
+            completion(nil)
+            return
+        }
+
+        do {
+            let spaceApi = try JSONDecoder().decode(SpaceApi.self, from: data)
+            completion(spaceApi)
+            print(data)
+        } catch {
+            print("Error decoding JSON: \(error)")
+            completion(nil)
+        }
+    }
     task.resume()
 }
 
@@ -63,9 +98,9 @@ public func readLocalFile(forName name: String) -> Foundation.Data? {
 public func parse(jsonData: Foundation.Data) {
     do {
         let decodedData = try JSONDecoder().decode(SpaceApi.self, from: jsonData)
-        print("Data Api: ", decodedData.data.api)
-        print("url: ", decodedData.url)
-        print("====================")
+        //print("Data Api: ", decodedData.data.api)
+        //print("url: ", decodedData.url)
+        //print("====================")
     } catch {
         print(error)
     }
@@ -88,73 +123,106 @@ public func loadjson(fromURLString urlString: String, completion: @escaping (Res
 
 struct Hackspace: Hashable, Identifiable {
     var id = UUID()
-    //  var image: String
     var title: String
+    var apiUrl: String
 }
 
 // MARK: - Views
 
 struct HackspaceListView: View {
     var hackspaces: [Hackspace]
+    var onSelectHackspace: (Hackspace) -> Void
 
     var body: some View {
-        List(hackspaces) {
-            let hackspace = $0
+        List(hackspaces) { hackspace in
             HStack {
-                // Image(systemName: hackspace.image)
-                Text(hackspace.title)
+                Button(action: {
+                    self.onSelectHackspace(hackspace)
+                }) {
+                    Text(hackspace.title)
+                }
             }
         }
     }
 
-    init(hackspaces: [Hackspace]) {
+    init(hackspaces: [Hackspace], onSelectHackspace: @escaping (Hackspace) -> Void) {
         self.hackspaces = hackspaces
+        self.onSelectHackspace = onSelectHackspace
     }
 }
 
+
 struct FavoritesView: View {
-    let favorites: [Hackspace] = [Hackspace( /* image: "globe", */ title: "Section77")]
+    let favorites: [Hackspace] = [
+        Hackspace(title: "Section77", apiUrl: "https://api.section77.de"),
+        // Add more favorite hackspaces as needed
+    ]
+    
+    @State private var selectedHackspace: Hackspace?
 
     var body: some View {
-        if favorites.isEmpty {
-            Text("nicht gefunden")
-        } else {
-            HackspaceListView(hackspaces: favorites)
+        VStack {
+            if favorites.isEmpty {
+                Text("Favorites not found")
+            } else {
+                HackspaceListView(hackspaces: favorites, onSelectHackspace: { hackspace in
+                    self.selectedHackspace = hackspace
+                })
+            }
         }
     }
 }
 
+
 struct DirectoryView: View {
     @State private var hackspaceArray: [Hackspace] = []
+    @State private var selectedHackspace: Hackspace?
     @State private var isRefreshing = false
 
     var body: some View {
         NavigationView {
             VStack {
-                HackspaceListView(hackspaces: hackspaceArray)
+                HackspaceListView(hackspaces: hackspaceArray, onSelectHackspace: selectHackspace)
                     .refreshable {
-                        makeAPICall { [self] result in
-                            if let keys = result {
-                                self.hackspaceArray = keys.map { Hackspace(title: $0) }
-                            }
-                        }
+                        directoryAPIWrapper()
                     }
                     .onAppear {
                         // Load initial data
-                        loadInitialData()
+                        directoryAPIWrapper()
                     }
+            }
+            .navigationTitle("Hackspaces")
+            .sheet(item: $selectedHackspace) { hackspace in
+                // Show details for selected hackspace
+                HackspaceDetailView(hackspace: hackspace)
             }
         }
     }
 
-    func loadInitialData() {
-        makeAPICall { [self] result in
+    func directoryAPIWrapper() {
+        makeDirectoryAPICall { [self] result in
             if let keys = result {
-                self.hackspaceArray = keys.map { Hackspace(title: $0) }
+                self.hackspaceArray = keys.map { Hackspace(title: $0.name, apiUrl: $0.apiUrl) }
             }
         }
     }
+
+    func selectHackspace(_ hackspace: Hackspace) {
+        // Call individual API for the selected hackspace
+        self.selectedHackspace = hackspace
+        /*
+        makeSpaceAPICall(for: hackspace.apiUrl) { apiData in
+            // Handle API response for the selected hackspace
+            if let apiData = apiData {
+                // Update selectedHackspace with details if needed
+                
+                print("API data for \(hackspace.title): \(apiData)")
+            }
+        }
+         */
+    }
 }
+
 
 struct ContentView: View {
     var body: some View {
@@ -177,6 +245,48 @@ struct ContentView: View {
         .padding()
     }
 }
+                                            
+struct HackspaceDetailView: View {
+    let hackspace: Hackspace
+    @State private var apiResponse: String = "Loading..." // Initial value for API response
+
+    var body: some View {
+        VStack {
+            Text("Hackspace Detail: \(hackspace.title)")
+                .font(.title)
+                .padding()
+
+            TextField("API Response", text: $apiResponse)
+                .disabled(true) // Make the TextField read-only
+
+            Button("Call API") {
+                spaceAPIWrapper()
+            }
+            .padding()
+        }
+        .onAppear {
+            // Optionally, you can make the API call when the view appears
+            // makeAPICall()
+        }
+    }
+    
+    func spaceAPIWrapper() {
+            makeSpaceAPICall(for: hackspace.apiUrl) { spaceApi in
+                if let spaceApi = spaceApi {
+                    // Update UI with API response data
+                    DispatchQueue.main.async {
+                        self.apiResponse = "\(spaceApi)" // Update API response text
+                    }
+                    print("API data for \(hackspace.title): \(spaceApi)")
+                } else {
+                    // Handle API call failure
+                    self.apiResponse = "Error fetching data"
+                }
+            }
+        }
+}
+                                             
+                        
 
 // MARK: - Previews
 


### PR DESCRIPTION
- Modified the original Directory call function to return a tuple with the Space Name and Space API URL
- Added New function to dynamically Query and retrieve the JSON for individual APIs
- Modified SpaceApi Model to aid in JSON parsing and decoding
- Added new function to retrieve and display the logo associated with a particular Hackspace
- Added A green filled-in circle when HackSpace is Open and red hollow circle when HackSpace status is closed